### PR TITLE
fix: replace deprecated attachHeaders with newAttachHeadersInterceptor

### DIFF
--- a/plugin/src/main/resources/service.hbs
+++ b/plugin/src/main/resources/service.hbs
@@ -132,7 +132,7 @@ public final class {{outerClassName}} {
                         .flatMap(request -> {
                             return Mono.<{{resultProto}}>create(emitter -> {
                                 Metadata metadata = extractMetadata(serverRequest.headers());
-                                MetadataUtils.attachHeaders(stub, metadata).{{methodName}}(request, new StreamObserver<{{resultProto}}>() {
+                                stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).{{methodName}}(request, new StreamObserver<{{resultProto}}>() {
                                     @Override
                                     public void onNext({{resultProto}} value) {
                                         emitter.success(value);


### PR DESCRIPTION
## Summary
Updates gRPC service template to use `newAttachHeadersInterceptor` instead of deprecated `attachHeaders` method.

## Changes
- Replaced `MetadataUtils.attachHeaders(stub, metadata)` with `stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))` in `service.hbs`

## Reason
`MetadataUtils.attachHeaders` was removed in gRPC Java v1.58.0. This change ensures compatibility with the latest gRPC Java version.

- ref : https://github.com/grpc/grpc-java/pull/10443

## Impact
- ✅ Backward compatible
- ✅ No breaking changes
- ✅ Generated code will work with gRPC Java v1.58.0+